### PR TITLE
Fix: (Documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export const selectors = {
 const CounterState = props => (
   <State
     initialState={initialState}
-    actions={actiosn}
+    actions={actions}
     selectors={selectors}
     {...props}
   />


### PR DESCRIPTION
Fix misspelling of `actions` in documentation.