### PR TITLE
fix: Ensure lazy initialization happens only once per context key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <a href="https://codecov.io/gh/diegohaz/constate/branch/master"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/diegohaz/constate/master.svg?style=flat-square"></a>
 
 
-~1 kB React state management library that lets you write contextual state as if it were local state using [React Hooks](https://reactjs.org/docs/hooks-intro.html) and [React Context](https://reactjs.org/docs/context.html).
+~ 1.5 kB React state management library that lets you write contextual state as if it were local state using [React Hooks](https://reactjs.org/docs/hooks-intro.html) and [React Context](https://reactjs.org/docs/context.html).
 
 <br>
 

--- a/src/utils/redefineState.ts
+++ b/src/utils/redefineState.ts
@@ -4,7 +4,7 @@ function redefineState<State, Action>(
   key: ContextKeyString<keyof State>,
   [contextState, setContextState]: ContextState<State>,
   [state, dispatch]: ContextReducer<State[keyof State], Action>,
-  transformState: React.Reducer<typeof state, any>
+  reducer: React.Reducer<typeof state, any>
 ): ContextReducer<typeof state, Action> {
   if (key) {
     return [
@@ -12,7 +12,7 @@ function redefineState<State, Action>(
       (nextState: any) =>
         setContextState(prevState => ({
           ...prevState,
-          [key]: transformState(prevState[key], nextState)
+          [key]: reducer(prevState[key], nextState)
         }))
     ];
   }

--- a/test/useContextReducer.test.tsx
+++ b/test/useContextReducer.test.tsx
@@ -64,8 +64,9 @@ test("local initialAction", () => {
 });
 
 test("shared initialAction", () => {
+  const reducerSpy = jest.fn(reducer) as typeof reducer;
   const useCounter = () =>
-    useContextReducer("counter1", reducer, 0, { type: "INCREMENT" });
+    useContextReducer("counter1", reducerSpy, 0, { type: "INCREMENT" });
   const Button = () => {
     const [, dispatch] = useCounter();
     return (
@@ -80,10 +81,12 @@ test("shared initialAction", () => {
     <Provider>
       <Button />
       <Value />
+      <Value />
     </Provider>
   );
   const { getByText } = render(<App />);
   expect(getByText("1")).toBeDefined();
   fireEvent.click(getByText("Button"));
   expect(getByText("2")).toBeDefined();
+  expect(reducerSpy).toHaveBeenCalledTimes(2);
 });

--- a/test/useContextState.test.tsx
+++ b/test/useContextState.test.tsx
@@ -39,7 +39,8 @@ test("shared state", () => {
 });
 
 test("lazy initialization", () => {
-  const useCounter = () => useContextState("counter1", () => 0);
+  const lazyInitialState = jest.fn(() => 0) as () => number;
+  const useCounter = () => useContextState("counter1", lazyInitialState);
   const Button = () => {
     const [, setCount] = useCounter();
     return (
@@ -62,6 +63,7 @@ test("lazy initialization", () => {
   expect(getByText("0")).toBeDefined();
   fireEvent.click(getByText("Button"));
   expect(getByText("1")).toBeDefined();
+  expect(lazyInitialState).toHaveBeenCalledTimes(1);
 });
 
 test("useContextKey", () => {


### PR DESCRIPTION
Related to #53

Lazy initialization was happening per consumer (component using `useContextState` or `useContextReducer`). This PR creates a contextual cache for lazy initial states so further consumers will use the cache instead of calling the `initialState` function (or `initialAction` for `useContextReducer`).