### PR TITLE
add `devtoolsName` prop to Provider to set redux-devtools-extension's instance name

### DIFF
--- a/src/createContext.tsx
+++ b/src/createContext.tsx
@@ -9,6 +9,7 @@ import useDevtools from "./utils/useDevtools";
 export type ProviderProps = {
   children: React.ReactNode;
   devtools?: boolean;
+  devtoolsName?: string;
 };
 
 function createHash(skipLength: number) {
@@ -44,11 +45,15 @@ function createProvider<State>(
   Context: React.Context<ContextState<State>>,
   initialState: State
 ) {
-  return function Provider({ children, devtools }: ProviderProps) {
+  return function Provider({
+    children,
+    devtools,
+    devtoolsName
+  }: ProviderProps) {
     const state = React.useState(initialState);
     const value = React.useMemo(() => state, [state[0]]);
 
-    useDevtools(state, { enabled: devtools });
+    useDevtools(state, { enabled: devtools, name: devtoolsName });
 
     return <Context.Provider value={value}>{children}</Context.Provider>;
   };

--- a/src/utils/useDevtools.ts
+++ b/src/utils/useDevtools.ts
@@ -6,7 +6,7 @@ const devtoolsExtension =
 
 function useDevtools<State>(
   [state, setState]: ContextState<State>,
-  { enabled }: { enabled?: boolean } = {}
+  { enabled, name }: { enabled?: boolean; name?: string } = {}
 ) {
   const devtools = React.useRef<ReturnType<
     ReduxDevtoolsExtension["connect"]
@@ -17,7 +17,7 @@ function useDevtools<State>(
   React.useEffect(
     () => {
       if (enabled && devtoolsExtension) {
-        devtools.current = devtoolsExtension.connect();
+        devtools.current = devtoolsExtension.connect({ name });
         devtools.current.init(state);
         devtools.current.subscribe(message => {
           if (message.type === "DISPATCH" && message.state) {


### PR DESCRIPTION
For cases where `constate` default Provider/from `createContext` one is used in parts of an app instead of globally, we can customize the instance name instead of generated `Instance 1...N`.

Not sure about the prop name, it can be changed to more meaningful one.