### PR TITLE
Update useCounter example hook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import createContainer from "constate";
 // 1️⃣ Create a custom hook as usual
 function useCounter() {
   const [count, setCount] = useState(0);
-  const increment = () => setCount(count => count + 1);
+  const increment = () => setCount(prevCount => prevCount + 1);
   return { count, increment };
 }
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import createContainer from "constate";
 // 1️⃣ Create a custom hook as usual
 function useCounter() {
   const [count, setCount] = useState(0);
-  const increment = () => setCount(count + 1);
+  const increment = () => setCount(count => count + 1);
   return { count, increment };
 }
 


### PR DESCRIPTION
The `increment` that is created within the current example hook will have its `count` bound to the value from the last time that the hook was run, which could conceivably cause multiple calls to `increment` to do yield the same result, rather than incrementing the value with each call.

By changing the example to use the "updater" form of `setCount`, we ensure that we always get the latest state. Dan Abramov wrote about this as one of the solutions to his setInterval hook over in this blog post: https://overreacted.io/making-setinterval-declarative-with-react-hooks/#second-attempt