### PR TITLE
feat: Set displayName of Context and Provider (#79)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,7 @@ function createUseContext<P, V>(
 ) {
   const Context = React.createContext(defaultValue as V);
 
-  const Provider = (props: { children?: React.ReactNode } & P) => {
+  const Provider: React.FunctionComponent<P> = props => {
     const value = useValue(props);
     // createMemoInputs won't change between renders
     const memoizedValue = createMemoInputs
@@ -33,6 +33,11 @@ function createUseContext<P, V>(
       </Context.Provider>
     );
   };
+
+  if (useValue.name) {
+    Context.displayName = `${useValue.name}.Context`;
+    Provider.displayName = `${useValue.name}.Provider`;
+  }
 
   const useContext = () => React.useContext(Context);
   useContext.Context = Context;

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -117,3 +117,15 @@ test("provider props", () => {
   fireEvent.click(getByText("Increment"));
   expect(getByText("11")).toBeDefined();
 });
+
+test("displayName with named hook", () => {
+  const Container = createContainer(useCounter);
+  expect(Container.Provider.displayName).toBe("useCounter.Provider");
+  expect(Container.Context.displayName).toBe("useCounter.Context");
+});
+
+test("displayName with anonymous hook", () => {
+  const Container = createContainer(() => {});
+  expect(Container.Provider.displayName).toBeUndefined();
+  expect(Container.Context.displayName).toBeUndefined();
+});


### PR DESCRIPTION
Implementation of #79. Please let me know if I missed something.

I changed the typings of the Provider so I can access "displayName" without casting. With the `FunctionComponent` interface, it is also not necessary to define the `children` property.