### PR TITLE
feat: Remove deprecated `createMemoDeps` parameter

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,28 +24,7 @@ function constate<P, V, S extends Array<SplitValueFunction<V>>>(
 
   const Provider: React.FunctionComponent<P> = props => {
     const value = useValue(props);
-    const [createMemoDeps] = splitValues;
-    const deps = createMemoDeps && createMemoDeps(value);
-
-    if (isDev && Array.isArray(deps)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "[constate] Passing `createMemoDeps` as the second argument is deprecated.",
-        "Please, use `React.useMemo` in your custom hook instead.",
-        "See https://github.com/diegohaz/constate/issues/98"
-      );
-    }
-
-    // deps won't change between renders
-    const memoizedValue = Array.isArray(deps)
-      ? React.useMemo(() => value, deps)
-      : value;
-
-    return (
-      <Context.Provider value={memoizedValue}>
-        {props.children}
-      </Context.Provider>
-    );
+    return <Context.Provider value={value}>{props.children}</Context.Provider>;
   };
 
   if (isDev && useValue.name) {

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -207,52 +207,6 @@ test("as tuple with multiple split using hooks inside splitValue", () => {
   expect(getByText("8")).toBeDefined();
 });
 
-test("createMemoDeps", () => {
-  const useCounterContext = constate(useCounter, value => [value.count]);
-  const Increment = () => {
-    const { increment } = useCounterContext();
-    return <button onClick={increment}>Increment</button>;
-  };
-  const Count = () => {
-    const { count } = useCounterContext();
-    return <div>{count}</div>;
-  };
-  const App = () => (
-    <useCounterContext.Provider>
-      <Increment />
-      <Count />
-    </useCounterContext.Provider>
-  );
-  const { getByText } = render(<App />);
-  expect(getByText("0")).toBeDefined();
-  fireEvent.click(getByText("Increment"));
-  expect(getByText("1")).toBeDefined();
-  fireEvent.click(getByText("Increment"));
-  expect(getByText("2")).toBeDefined();
-});
-
-test("empty createMemoDeps", () => {
-  const useCounterContext = constate(useCounter, () => []);
-  const Increment = () => {
-    const { increment } = useCounterContext();
-    return <button onClick={increment}>Increment</button>;
-  };
-  const Count = () => {
-    const { count } = useCounterContext();
-    return <div>{count}</div>;
-  };
-  const App = () => (
-    <useCounterContext.Provider>
-      <Increment />
-      <Count />
-    </useCounterContext.Provider>
-  );
-  const { getByText } = render(<App />);
-  expect(getByText("0")).toBeDefined();
-  fireEvent.click(getByText("Increment"));
-  expect(getByText("0")).toBeDefined();
-});
-
 test("without provider", () => {
   const [, useCount] = constate(useCounter);
   const Count = () => {


### PR DESCRIPTION
This PR removes the deprecated `createMemoDeps` function that was passed as the second argument of the constate function.

So, this is a breaking change and should be released as `v2.0.0`.

**Before**:
```jsx
const useCounterContext = createUseContext(useCounter, value => [value.count]);
```

**After**:
```jsx
const useCounterContext = createUseContext(() => {
  const value = useCounter();
  return useMemo(() => value, [value.count]);
});
```