### PR TITLE
feat: Deprecate old function/object API

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,17 @@ function createUseContext(context: React.Context<any>): any {
   };
 }
 
+function warnAboutObjectUsage() {
+  if (isDev) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[constate] Getting { Context, Provider } from constate is deprecated. " +
+        "Please, use the tuple format instead. " +
+        "See instructions on https://github.com/diegohaz/constate/pull/100"
+    );
+  }
+}
+
 function constate<P, V, S extends Array<SplitValueFunction<V>>>(
   useValue: (props: P) => V,
   ...splitValues: S
@@ -33,11 +44,33 @@ function constate<P, V, S extends Array<SplitValueFunction<V>>>(
   }
 
   // const useCounterContext = constate(...)
-  const useContext = createUseContext(Context);
+  const useContext: any = () => {
+    if (isDev) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[constate] Using the return value of constate as a hook is deprecated. " +
+          "Please, use the tuple format instead. " +
+          "See instructions on https://github.com/diegohaz/constate/pull/100"
+      );
+    }
+    return createUseContext(Context)();
+  };
 
   // const { Context, Provider } = constate(...)
-  useContext.Context = Context;
-  useContext.Provider = Provider;
+  Object.defineProperties(useContext, {
+    Context: {
+      get() {
+        warnAboutObjectUsage();
+        return Context;
+      }
+    },
+    Provider: {
+      get() {
+        warnAboutObjectUsage();
+        return Provider;
+      }
+    }
+  });
 
   const tuple = [] as any[];
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,7 @@ function warnAboutObjectUsage() {
     console.warn(
       "[constate] Getting { Context, Provider } from constate is deprecated. " +
         "Please, use the tuple format instead. " +
-        "See instructions on https://github.com/diegohaz/constate/pull/100"
+        "See instructions on https://github.com/diegohaz/constate/pull/101"
     );
   }
 }
@@ -50,7 +50,7 @@ function constate<P, V, S extends Array<SplitValueFunction<V>>>(
       console.warn(
         "[constate] Using the return value of constate as a hook is deprecated. " +
           "Please, use the tuple format instead. " +
-          "See instructions on https://github.com/diegohaz/constate/pull/100"
+          "See instructions on https://github.com/diegohaz/constate/pull/101"
       );
     }
     return createUseContext(Context)();


### PR DESCRIPTION
This PR deprecates old APIs. There's no breaking changes, only deprecation warnigns.

### Migration instructions

**Before**:
```jsx
import createUseContext from "constate";

const useCounterContext = createUseContext(useCounter);

<useCounterContext.Provider>
  ...
</useCounterContext.Provider>
```

**After**:
```jsx
import constate from "constate";

const [CounterProvider, useCounterContext] = constate(useCounter);

<CounterProvider>
  ...
</CounterProvider>
```