### PR TITLE
Allow React 17 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
     "typescript": "4.0.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
React 17 [was released today](https://reactjs.org/blog/2020/10/20/react-v17.html). I haven't yet tested constate with this new release, but there's a good chance that it'll work just fine.