### PR TITLE
fix: 🐛 make types @types/react@18 compatible

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,7 +68,10 @@ function constate<Props, Value, Selectors extends Selector<Value>[]>(
     createContext(useValue.name);
   }
 
-  const Provider: React.FC<Props> = ({ children, ...props }) => {
+  const Provider: React.FC<React.PropsWithChildren<Props>> = ({
+    children,
+    ...props
+  }) => {
     const value = useValue(props as Props);
     let element = children as React.ReactElement;
     for (let i = 0; i < contexts.length; i += 1) {


### PR DESCRIPTION
In react 18 types `children` was removed from `FC` type. 

Changes of this PR are compatible with 17 and 18 typings versions.