### PR TITLE
fix: Add exports map and named export for nodenext consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.3.4](https://github.com/diegohaz/constate/compare/v3.3.3...v3.3.4) (2026-05-14)
+
+
+### Bug Fixes
+
+* Add `exports` map and `.d.cts`/`.d.mts` declarations so consumers using `moduleResolution: "nodenext"` get the correct call signature for `import constate from "constate"`
+* Add named `constate` export for `import { constate } from "constate"`
+
 ### [3.3.3](https://github.com/diegohaz/constate/compare/v3.3.2...v3.3.3) (2025-04-01)
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,21 @@
   "module": "dist/constate.es.js",
   "jsnext:main": "dist/constate.es.js",
   "unpkg": "dist/constate.min.js",
-  "types": "dist/ts/src",
+  "types": "dist/ts/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/ts/src/index.d.mts",
+        "default": "./dist/constate.es.js"
+      },
+      "require": {
+        "types": "./dist/ts/src/index.d.cts",
+        "default": "./dist/constate.cjs.js"
+      },
+      "default": "./dist/constate.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "author": {
     "name": "Diego Haz",
@@ -28,7 +42,7 @@
     "lint": "eslint . --ext js,ts,tsx",
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
-    "build": "tsc --emitDeclarationOnly && rollup -c",
+    "build": "tsc --emitDeclarationOnly && rollup -c && node scripts/emit-cts.js",
     "prerelease": "npm run lint && npm test && npm run build",
     "release": "standard-version",
     "postpublish": "git push origin HEAD --follow-tags",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constate",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Yet another React state management library that lets you work with local state and scale up to global state with ease",
   "license": "MIT",
   "repository": "diegohaz/constate",

--- a/scripts/emit-cts.js
+++ b/scripts/emit-cts.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const path = require("path");
+
+const src = path.join(__dirname, "..", "dist", "ts", "src", "index.d.ts");
+const cts = path.join(__dirname, "..", "dist", "ts", "src", "index.d.cts");
+const mts = path.join(__dirname, "..", "dist", "ts", "src", "index.d.mts");
+
+fs.copyFileSync(src, cts);
+fs.copyFileSync(src, mts);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,7 +46,7 @@ function createUseContext(context: React.Context<any>): any {
   };
 }
 
-function constate<Props, Value, Selectors extends Selector<Value>[]>(
+export function constate<Props, Value, Selectors extends Selector<Value>[]>(
   useValue: (props: Props) => Value,
   ...selectors: Selectors
 ): ConstateTuple<Props, Value, Selectors> {


### PR DESCRIPTION
Summary
===

Under `moduleResolution: "nodenext"`, consumers currently see `import constate from "constate"` resolve to the module namespace rather than the function — TS reports `This expression is not callable`. The cause is the package shipping CJS at runtime (`exports.default = constate`) but exposing only an ESM-shaped `.d.ts` (`export default constate`), with no `exports` map to disambiguate per condition.

This PR fixes that two ways so consumers have options:

1. Adds a proper `exports` field with separate `import` / `require` conditions, each pointing to a declaration file whose extension matches its runtime format (`.d.mts` for ESM, `.d.cts` for CJS). The `.d.mts` is required because `constate`'s `package.json` has no `"type": "module"`, so without an explicit `.mts` extension Node treats `.d.ts` files as CJS regardless of which condition resolved them.
2. Adds a named `constate` export so consumers can write `import { constate } from "constate"` as an alternative that sidesteps default-import interop entirely.

Existing `import constate from "constate"` usage continues to work in every resolution mode — this is backwards-compatible.

Changes
===

- Add named `export function constate` alongside the existing default export
- Add `exports` map with `types`/`default` per `import` and `require` condition
- Update `build` to copy the emitted `index.d.ts` to `index.d.cts` and `index.d.mts` (`scripts/emit-cts.js`)
- Bump to 3.3.4 + CHANGELOG entry

Test plan
===

- [x] `yarn test` — all existing tests pass
- [x] `yarn type-check` — clean
- [x] Sandbox consumer with `moduleResolution: "nodenext"`, `"type": "module"`: `import constate from "constate"` and `import { constate } from "constate"` both type-check
- [x] Sandbox consumer with `moduleResolution: "nodenext"`, no `"type"` (CJS): both import styles type-check
- [x] Regression check with `moduleResolution: "bundler"`: still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)