### PR TITLE
Replace root LICENSE symlink and document pnpm install

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-packages/constate/LICENSE
+MIT License
+
+Copyright (c) 2017 Diego Haz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/constate/README.md
+++ b/packages/constate/README.md
@@ -132,6 +132,12 @@ Yarn:
 yarn add constate
 ```
 
+pnpm:
+
+```sh
+pnpm add constate
+```
+
 ## API
 
 ### `constate(useValue[, ...selectors])`


### PR DESCRIPTION
## Motivation

Two small follow-ups to #165:

- The root `LICENSE` was committed as a symlink to `packages/constate/LICENSE`, but GitHub's license detector and the source-archive tarballs don't follow the symlink — the repo page shows no license badge, and consumers that read the archive don't get the file inline.
- The Installation section in `packages/constate/README.md` listed only npm and Yarn even though the repo itself now runs on pnpm and the Contributing section already directs contributors to use it.

## Solution

- Replaced the root `LICENSE` symlink with a regular file containing the same MIT text as `packages/constate/LICENSE`. `git mode change 120000 => 100644`; the package-level copy is unchanged so npm tarballs and the repo root now both ship the file inline.
- Added a `pnpm:` block (`pnpm add constate`) after the Yarn block in `packages/constate/README.md`, matching the surrounding label/fence style.

## Verification

- `pnpm lint` — oxlint + oxfmt clean.
- `ls -la LICENSE` shows `-rw-r--r--` (regular file, 1066 B); `cmp LICENSE packages/constate/LICENSE` is silent (byte-for-byte identical).
- Three parallel pre-commit reviewers (Claude Code subagent + Codex CLI + Cursor CLI) returned zero findings on the combined diff.