### PR TITLE
Repair CHANGELOG.md format after Changesets migration

### DIFF
--- a/.changeset/get-changelog-entry.test.ts
+++ b/.changeset/get-changelog-entry.test.ts
@@ -6,6 +6,22 @@ import path from "path";
 import applyReleasePlan from "@changesets/apply-release-plan";
 import { expect, test } from "vitest";
 
+const config = {
+  changelog: ["./changelog.ts", {}],
+  updateInternalDependencies: "patch",
+  ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+    onlyUpdatePeerDependentsWhenOutOfRange: true,
+  },
+  bumpVersionsWithWorkspaceProtocolOnly: false,
+  prettier: false,
+  ignore: [],
+  privatePackages: { version: false, tag: false },
+} as const;
+
+const releasePlanRunner = applyReleasePlan as (
+  ...arguments_: any[]
+) => Promise<string[]>;
+
 test("changesets getChangelogEntry hook", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "changesets-test-"));
   try {
@@ -55,22 +71,6 @@ test("changesets getChangelogEntry hook", async () => {
       ],
     } as const;
 
-    const config = {
-      changelog: ["./changelog.ts", {}],
-      updateInternalDependencies: "patch",
-      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-        onlyUpdatePeerDependentsWhenOutOfRange: true,
-      },
-      bumpVersionsWithWorkspaceProtocolOnly: false,
-      prettier: false,
-      ignore: [],
-      privatePackages: { version: false, tag: false },
-    } as const;
-
-    const releasePlanRunner = applyReleasePlan as (
-      ...arguments_: any[]
-    ) => Promise<string[]>;
-
     const touched = await releasePlanRunner(releasePlan, packages, config);
     expect(Array.isArray(touched)).toBe(true);
 
@@ -93,6 +93,73 @@ test("changesets getChangelogEntry hook", async () => {
       ### Other updates
 
       - Chore: update docs
+      "
+    `);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("prepends the new entry directly under the existing `# Changelog` header", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "changesets-test-"));
+  try {
+    const packageDir = path.join(tempDir, "pkg-a");
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "pkg-a", version: "1.0.0" }, null, 2),
+    );
+    await writeFile(
+      path.join(packageDir, "CHANGELOG.md"),
+      "# Changelog\n\n## 1.0.0\n\nFirst official release.\n",
+    );
+
+    const releasePlan = {
+      changesets: [
+        {
+          id: "fake-id-1",
+          summary: "New cool feature",
+          releases: [{ name: "pkg-a", type: "minor" }],
+        },
+      ],
+      releases: [
+        {
+          name: "pkg-a",
+          type: "minor",
+          newVersion: "1.1.0",
+          changesets: ["fake-id-1"],
+        },
+      ],
+      preState: undefined,
+    } as const;
+
+    const packages = {
+      root: { dir: process.cwd() },
+      packages: [
+        {
+          dir: packageDir,
+          packageJson: { name: "pkg-a", version: "1.0.0" },
+        },
+      ],
+    } as const;
+
+    await releasePlanRunner(releasePlan, packages, config);
+
+    const changelog = await readFile(
+      path.join(packageDir, "CHANGELOG.md"),
+      "utf8",
+    );
+
+    expect(changelog).toMatchInlineSnapshot(`
+      "# Changelog
+
+      ## 1.1.0
+
+      - New cool feature
+
+      ## 1.0.0
+
+      First official release.
       "
     `);
   } finally {

--- a/packages/constate/CHANGELOG.md
+++ b/packages/constate/CHANGELOG.md
@@ -1,20 +1,18 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. Releases are managed with [Changesets](https://github.com/changesets/changesets).
-
-### [3.3.3](https://github.com/diegohaz/constate/compare/v3.3.2...v3.3.3) (2025-04-01)
+## [3.3.3](https://github.com/diegohaz/constate/compare/v3.3.2...v3.3.3) (2025-04-01)
 
 ### Bug Fixes
 
 - Allow React 19 as a peer dependency ([#161](https://github.com/diegohaz/constate/issues/161)) ([2054d86](https://github.com/diegohaz/constate/commit/2054d86b918a93c6be97bcf4f0705b3eb6326c25))
 
-### [3.3.2](https://github.com/diegohaz/constate/compare/v3.3.1...v3.3.2) (2022-04-18)
+## [3.3.2](https://github.com/diegohaz/constate/compare/v3.3.1...v3.3.2) (2022-04-18)
 
 ### Bug Fixes
 
 - Allow React 18 as a peer dependency ([6611f1c](https://github.com/diegohaz/constate/commit/6611f1c74f12281d6e7e7d0c2633f9d7178d2efb))
 
-### [3.3.1](https://github.com/diegohaz/constate/compare/v3.3.0...v3.3.1) (2022-04-18)
+## [3.3.1](https://github.com/diegohaz/constate/compare/v3.3.0...v3.3.1) (2022-04-18)
 
 ### Bug Fixes
 
@@ -38,7 +36,7 @@ All notable changes to this project will be documented in this file. Releases ar
 
 - Allow React 17 as a peerDependency ([#122](https://github.com/diegohaz/constate/issues/122)) ([0f69b83](https://github.com/diegohaz/constate/commit/0f69b8336a53a6ef8797795bc618dc3b884a189c))
 
-### [3.0.1](https://github.com/diegohaz/constate/compare/v3.0.0...v3.0.1) (2020-09-08)
+## [3.0.1](https://github.com/diegohaz/constate/compare/v3.0.0...v3.0.1) (2020-09-08)
 
 ### Bug Fixes
 
@@ -99,13 +97,13 @@ All notable changes to this project will be documented in this file. Releases ar
 - Deprecate old function/object API ([#101](https://github.com/diegohaz/constate/issues/101)) ([c102a31](https://github.com/diegohaz/constate/commit/c102a31d00b23026256f09bbede11488e04f6dc2))
 - Remove deprecated `createMemoDeps` parameter ([#100](https://github.com/diegohaz/constate/issues/100)) ([553405d](https://github.com/diegohaz/constate/commit/553405df07144cde2009a9e2590012cd1fee548f))
 
-### [1.3.2](https://github.com/diegohaz/constate/compare/v1.3.1...v1.3.2) (2019-10-20)
+## [1.3.2](https://github.com/diegohaz/constate/compare/v1.3.1...v1.3.2) (2019-10-20)
 
 ### Bug Fixes
 
 - Remove unnecessary code from production ([a0d22bf](https://github.com/diegohaz/constate/commit/a0d22bfebc409dbea081c13ac61a84ca2022bc0b))
 
-### [1.3.1](https://github.com/diegohaz/constate/compare/v1.3.0...v1.3.1) (2019-10-20)
+## [1.3.1](https://github.com/diegohaz/constate/compare/v1.3.0...v1.3.1) (2019-10-20)
 
 ### Bug Fixes
 
@@ -130,12 +128,12 @@ All notable changes to this project will be documented in this file. Releases ar
 
 - Fix React peer dependency range ([7132e3d](https://github.com/diegohaz/constate/commit/7132e3d))
 
-# [1.1.0](https://github.com/diegohaz/constate/compare/v1.0.0...v1.1.0) (2019-04-14)
+## [1.1.0](https://github.com/diegohaz/constate/compare/v1.0.0...v1.1.0) (2019-04-14)
 
 ### Features
 
 - Return a hook from the createContainer method ([#78](https://github.com/diegohaz/constate/issues/78)) ([8de6eb6](https://github.com/diegohaz/constate/commit/8de6eb6)), closes [#77](https://github.com/diegohaz/constate/issues/77)
 
-# [1.0.0](https://github.com/diegohaz/constate/compare/v0.9.0...v1.0.0) (2019-02-06)
+## [1.0.0](https://github.com/diegohaz/constate/compare/v0.9.0...v1.0.0) (2019-02-06)
 
 First official release.


### PR DESCRIPTION
## Summary

- Drop the `All notable changes to this project will be documented in this file…` paragraph from `packages/constate/CHANGELOG.md`. Changesets' `prependFile` inserts each new release right after the first newline of the file, so this paragraph was being wedged mid-file (between `# Changelog` and every new release). You can see the result in the release PR #166, where the paragraph appears below the `4.0.0` entry and above the prior `3.3.3` entry.
- Normalize every prior version heading to `##`. The legacy entries mixed `### [x.y.z]` for patches and `# [x.y.z]` for the original `1.x` majors. The Changesets action extracts a release's PR-body section by scanning from `## VERSION` to the next `## ` heading, so the mismatched levels caused the upcoming `4.0.0` section in #166 to absorb the older `### [3.3.x]` entries.
- Extend the `.changeset/get-changelog-entry.test.ts` suite with a regression test that seeds an existing `# Changelog` file and asserts the new release lands directly under the title, with no stray text in between.

Once this is merged, the release PR (#166) will be regenerated by the Changesets action with the correct formatting.

## Test plan

- [x] `pnpm test` — both existing and new test pass
- [x] `pnpm lint`
- [x] `pnpm tsc`
- [ ] After merge, confirm the regenerated release PR shows only the `4.0.0` entry in its body

🤖 Generated with [Claude Code](https://claude.com/claude-code)