### PR TITLE
Automerge @testing-library updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,7 @@
         "/^vite/",
         "/^vitest/",
         "/^typescript/",
+        "/^@testing-library//",
         "jsdom"
       ],
       "automerge": true,


### PR DESCRIPTION
## Summary
- Add `/^@testing-library//` to the automerge package rule in `renovate.json` so `@testing-library/*` updates land automatically alongside the other dev/test dependencies (`@types/*`, `oxlint`, `oxfmt`, `rolldown`, `vite`, `vitest`, `typescript`, `jsdom`) that already automerge.

## Test plan
- [ ] Renovate picks up the new rule on the next scan and applies `automerge: true` to `@testing-library/*` PRs (currently the repo only depends on `@testing-library/react`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)