### PR TITLE
Rename default branch references from master to main

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["examples"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -2,7 +2,7 @@ name: Release Preview
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/packages/constate/README.md
+++ b/packages/constate/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/diegohaz/constate/master/logo/logo.png" alt="constate logo" width="300" />
+  <img src="https://raw.githubusercontent.com/diegohaz/constate/main/logo/logo.png" alt="constate logo" width="300" />
 </p>
 
 # Constate
 
 <a href="https://npmjs.org/package/constate"><img alt="NPM version" src="https://img.shields.io/npm/v/constate.svg?style=flat-square"></a>
 <a href="https://npmjs.org/package/constate"><img alt="NPM downloads" src="https://img.shields.io/npm/dm/constate.svg?style=flat-square"></a>
-<a href="https://github.com/diegohaz/constate/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/diegohaz/constate/actions/workflows/ci.yml/badge.svg?branch=master"></a>
+<a href="https://github.com/diegohaz/constate/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/diegohaz/constate/actions/workflows/ci.yml/badge.svg?branch=main"></a>
 
 Write local state using [React Hooks](https://reactjs.org/docs/hooks-intro.html) and lift it up to [React Context](https://reactjs.org/docs/context.html) only when needed with minimum effort.
 
@@ -20,11 +20,11 @@ Write local state using [React Hooks](https://reactjs.org/docs/hooks-intro.html)
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://github.com/diegohaz/constate/blob/master/examples/src/counter/App.jsx">Counter</a></td>
-      <td><a href="https://github.com/diegohaz/constate/blob/master/examples/src/i18n/App.jsx">I18n</a></td>
-      <td><a href="https://github.com/diegohaz/constate/blob/master/examples/src/theming/App.jsx">Theming</a></td>
-      <td><a href="https://github.com/diegohaz/constate/blob/master/examples/src/typescript/App.tsx">TypeScript</a></td>
-      <td><a href="https://github.com/diegohaz/constate/blob/master/examples/src/wizard-form/App.jsx">Wizard Form</a></td>
+      <td><a href="https://github.com/diegohaz/constate/blob/main/examples/src/counter/App.jsx">Counter</a></td>
+      <td><a href="https://github.com/diegohaz/constate/blob/main/examples/src/i18n/App.jsx">I18n</a></td>
+      <td><a href="https://github.com/diegohaz/constate/blob/main/examples/src/theming/App.jsx">Theming</a></td>
+      <td><a href="https://github.com/diegohaz/constate/blob/main/examples/src/typescript/App.tsx">TypeScript</a></td>
+      <td><a href="https://github.com/diegohaz/constate/blob/main/examples/src/wizard-form/App.jsx">Wizard Form</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary

- Update `.changeset/config.json` `baseBranch` to `main`.
- Update GitHub Actions workflow triggers (`ci.yml`, `release.yml`, `release-preview.yml`) to `main`.
- Update `packages/constate/README.md` logo URL, CI badge `?branch=` query, and 5 example `/blob/<branch>/...` links to `main`.

The default branch has already been renamed on GitHub from `master` to `main`. This PR brings the in-repo references in line with that state so workflows fire, the changeset release flow uses the right base, and README assets resolve.

## Test plan

- [ ] CI runs on this PR (workflows trigger on `main`).
- [ ] After merge, push to `main` triggers Release workflow.
- [ ] README logo, CI badge, and example links resolve to `/main/...` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)