### PR TITLE
Add bugs metadata to constate package

### DIFF
--- a/packages/constate/package.json
+++ b/packages/constate/package.json
@@ -21,6 +21,9 @@
     "url": "git+https://github.com/diegohaz/constate.git",
     "directory": "packages/constate"
   },
+  "bugs": {
+    "url": "https://github.com/diegohaz/constate/issues"
+  },
   "funding": "https://github.com/sponsors/diegohaz",
   "files": [
     "dist",


### PR DESCRIPTION
Adds the npm `bugs` metadata field for the published `constate` package so npm users can discover the GitHub issue tracker from the package metadata.

Validation:
- `npm pkg get name version homepage repository bugs --silent` in `packages/constate`
- `npm pack --dry-run --ignore-scripts --json --silent` in `packages/constate`
- `git diff --check` (only the local Windows LF/CRLF warning)