### PR TITLE
chore: add npm bugs and homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
       "oxlint --type-aware --type-check"
     ]
   },
-  "packageManager": "pnpm@11.6.0"
+  "packageManager": "pnpm@11.6.0",
+  "homepage": "https://github.com/diegohaz/constate#readme",
+  "bugs": {
+    "url": "https://github.com/diegohaz/constate/issues"
+  }
 }


### PR DESCRIPTION
Adds missing `bugs.url` and `homepage` to `package.json` so npm users can navigate to the issue tracker and README from the package page.