### PR TITLE
Ignore pnpm store directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 .pnp
 .pnp.js
 


### PR DESCRIPTION
## Motivation

A project-local pnpm store can be created as `.pnpm-store/`, which should remain outside version control like other dependency artifacts.

## Solution

Add `.pnpm-store/` to the dependency section of `.gitignore`.

## Verification

- `git diff --check`
- `git check-ignore -v .pnpm-store/test-file`