### PR TITLE
Fix changesets action v2 inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Create PR or publish to npm
         uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          title: Publish
-          commit: Publish
-          publish: pnpm release
-          version: pnpm version-packages
+          pr-title: Publish
+          commit-message: Publish
+          publish-script: pnpm release
+          version-script: pnpm version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary\n\n- migrate the release workflow to the Changesets action v2 input names\n- restore version PR creation and npm publishing after the v2 upgrade\n\n## Verification\n\n- parsed .github/workflows/release.yml as YAML\n- ran git diff --check\n- confirmed the input names against the pinned changesets/action v2.1.0 metadata