### PR TITLE
Update Changesets

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@changesets/apply-release-plan": "8.0.0",
-    "@changesets/cli": "3.0.1",
+    "@changesets/apply-release-plan": "8.1.0",
+    "@changesets/cli": "3.0.2",
     "@changesets/config": "4.0.0",
     "@changesets/types": "7.0.0",
     "@types/node": "25.9.5",

--- a/patches/@changesets__apply-release-plan@8.0.0.patch
+++ b/patches/@changesets__apply-release-plan@8.0.0.patch
@@ -1,8 +1,0 @@
-diff --git a/dist/index.mjs b/dist/index.mjs
-index 595405f16c11621c1d96db816b47bce10816bef3..f59bff8977c21847a658b7ba6b8af87fd070bfc7 100644
---- a/dist/index.mjs
-+++ b/dist/index.mjs
-@@ -122,0 +123,3 @@ async function getChangelogEntry(cwd, release, releases, changesets, changelogFu
-+	if (typeof changelogFuncs.getChangelogEntry === "function") {
-+		return changelogFuncs.getChangelogEntry(release, changelogLines);
-+	}

--- a/patches/@changesets__apply-release-plan@8.1.0.patch
+++ b/patches/@changesets__apply-release-plan@8.1.0.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index ffe7f5cc11801bda72789240081ac33762a34dfe..f3e5cf856df0953bbfc6ba1b829af54113c9ae81 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -120,6 +120,9 @@ async function getChangelogEntry(cwd, release, releases, changesets, changelogFu
+ 	});
+ 	const relevantChangesets = changesets.filter((cs) => relevantChangesetIds.has(cs.id));
+ 	changelogLines.patch.push(Promise.resolve(changelogFuncs.getDependencyReleaseLine(relevantChangesets, dependentReleases, changelogOpts)));
++	if (typeof changelogFuncs.getChangelogEntry === "function") {
++		return changelogFuncs.getChangelogEntry(release, changelogLines);
++	}
+ 	const resolvedChangelogLines = {
+ 		major: await Promise.all(changelogLines.major),
+ 		minor: await Promise.all(changelogLines.minor),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,18 +106,18 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@changesets/apply-release-plan@8.0.0': a7b7d982d9e9c28647ae2a8674432d36d6ee6bad708e0cf5c6a82b92fce5f32e
+  '@changesets/apply-release-plan@8.1.0': 4cc5701c4fc577c33794ce6f4a2b288903f1867d14f75857145541b3ee03f89e
 
 importers:
 
   .:
     devDependencies:
       '@changesets/apply-release-plan':
-        specifier: 8.0.0
-        version: 8.0.0(patch_hash=a7b7d982d9e9c28647ae2a8674432d36d6ee6bad708e0cf5c6a82b92fce5f32e)
+        specifier: 8.1.0
+        version: 8.1.0(patch_hash=4cc5701c4fc577c33794ce6f4a2b288903f1867d14f75857145541b3ee03f89e)
       '@changesets/cli':
-        specifier: 3.0.1
-        version: 3.0.1
+        specifier: 3.0.2
+        version: 3.0.2
       '@changesets/config':
         specifier: 4.0.0
         version: 4.0.0
@@ -308,8 +308,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@changesets/apply-release-plan@8.0.0':
-    resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
+  '@changesets/apply-release-plan@8.1.0':
+    resolution: {integrity: sha512-M93HOGyX3ssg6He3b5NotaHtQVu6uajHS6UIQ28xKt2RzskCy73ayX4I914qBKjTJmrE4YFlELQjfcqxbmGLJw==}
     engines: {node: ^22.11 || ^24 || >=26}
 
   '@changesets/assemble-release-plan@7.0.0':
@@ -320,8 +320,8 @@ packages:
     resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
     engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/cli@3.0.1':
-    resolution: {integrity: sha512-3IVpRSgiKDj2aRbBHKtWTXSRH2/iR3bWxau9iQUoEsZjDhRIj9nhl90k7FWMxZAJvLgJBbgMq8+qS0xQsenYsQ==}
+  '@changesets/cli@3.0.2':
+    resolution: {integrity: sha512-t/omGJj/I+Jv0kmJAkj5cstYEdUQiJnpip2F+2m3F4lQ3kAZ3o8Exep4/Fm1qq4rvw6ovlhJvZNrKdwLJ4lkuQ==}
     engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
     hasBin: true
 
@@ -341,8 +341,8 @@ packages:
     resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
     engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/git@4.0.0':
-    resolution: {integrity: sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==}
+  '@changesets/git@4.0.1':
+    resolution: {integrity: sha512-6vWpIAC4LkpmlqaIu37ViT5enyd9+uBwAiGqCGhASvkSHBgx4PrtTGXWTMFYpDmZbjgyonyVgMciPrW4MqtJsA==}
     engines: {node: ^22.11 || ^24 || >=26}
 
   '@changesets/parse@1.0.0':
@@ -353,8 +353,8 @@ packages:
     resolution: {integrity: sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==}
     engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/read@1.0.0':
-    resolution: {integrity: sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==}
+  '@changesets/read@1.0.1':
+    resolution: {integrity: sha512-nzvSC6RcTiWf/dsuwZFXpLzGGsRHYCL68U3uHV7srsulU93aVWY7u2GEJiDZ+4GIIElfaW5EqtKC0UHroY+LTQ==}
     engines: {node: ^22.11 || ^24 || >=26}
 
   '@changesets/should-skip-package@1.0.0':
@@ -2084,11 +2084,11 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@changesets/apply-release-plan@8.0.0(patch_hash=a7b7d982d9e9c28647ae2a8674432d36d6ee6bad708e0cf5c6a82b92fce5f32e)':
+  '@changesets/apply-release-plan@8.1.0(patch_hash=4cc5701c4fc577c33794ce6f4a2b288903f1867d14f75857145541b3ee03f89e)':
     dependencies:
       '@changesets/config': 4.0.0
       '@changesets/format': 0.1.2
-      '@changesets/git': 4.0.0
+      '@changesets/git': 4.0.1
       '@changesets/should-skip-package': 1.0.0
       '@changesets/types': 7.0.0
       import-meta-resolve: 4.2.0
@@ -2107,17 +2107,17 @@ snapshots:
     dependencies:
       '@changesets/types': 7.0.0
 
-  '@changesets/cli@3.0.1':
+  '@changesets/cli@3.0.2':
     dependencies:
-      '@changesets/apply-release-plan': 8.0.0(patch_hash=a7b7d982d9e9c28647ae2a8674432d36d6ee6bad708e0cf5c6a82b92fce5f32e)
+      '@changesets/apply-release-plan': 8.1.0(patch_hash=4cc5701c4fc577c33794ce6f4a2b288903f1867d14f75857145541b3ee03f89e)
       '@changesets/assemble-release-plan': 7.0.0
       '@changesets/changelog-git': 1.0.0
       '@changesets/config': 4.0.0
       '@changesets/errors': 1.0.0
       '@changesets/get-dependents-graph': 3.0.0
-      '@changesets/git': 4.0.0
+      '@changesets/git': 4.0.1
       '@changesets/pre': 3.0.0
-      '@changesets/read': 1.0.0
+      '@changesets/read': 1.0.1
       '@changesets/should-skip-package': 1.0.0
       '@changesets/types': 7.0.0
       '@changesets/write': 1.0.1
@@ -2151,12 +2151,12 @@ snapshots:
       '@changesets/types': 7.0.0
       semver: 7.8.1
 
-  '@changesets/git@4.0.0':
+  '@changesets/git@4.0.1':
     dependencies:
       '@changesets/errors': 1.0.0
       '@changesets/types': 7.0.0
       '@manypkg/get-packages': 3.1.0
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       tinyexec: 1.3.0
 
   '@changesets/parse@1.0.0':
@@ -2170,9 +2170,9 @@ snapshots:
       '@changesets/types': 7.0.0
       '@manypkg/get-packages': 3.1.0
 
-  '@changesets/read@1.0.0':
+  '@changesets/read@1.0.1':
     dependencies:
-      '@changesets/git': 4.0.0
+      '@changesets/git': 4.0.1
       '@changesets/parse': 1.0.0
       '@changesets/types': 7.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,4 @@ allowBuilds:
   esbuild: true
 
 patchedDependencies:
-  "@changesets/apply-release-plan@8.0.0": patches/@changesets__apply-release-plan@8.0.0.patch
+  "@changesets/apply-release-plan@8.1.0": patches/@changesets__apply-release-plan@8.1.0.patch


### PR DESCRIPTION
## Motivation

Update the Changesets release tools under the repository's `changesets` dependency group. The existing patch calls the custom changelog hook before dependency release lines are added, so dependency-only entries lose their notes.

## Solution

Update the root development dependencies and regenerate the pnpm lockfile. Port the custom `getChangelogEntry` hook to `apply-release-plan` 8.1.0, with context around the insertion point, and call it after dependency release lines are added. For example, a dependency-only release retains `- Updated dependencies: pkg-b@2.0.0`.

The patch remains necessary because upstream does not expose this custom hook. It can be removed when upstream supports an equivalent hook or the repository stops using its custom changelog formatter. The hook placement change requires human review; automerge remains disabled.

## Dependencies

| Package | Workspace | Previous | Updated | Release notes |
| --- | --- | --- | --- | --- |
| `@changesets/apply-release-plan` | Root devDependencies | `8.0.0` | `8.1.0` | [Changelog](https://github.com/changesets/changesets/blob/main/packages/apply-release-plan/CHANGELOG.md#810) |
| `@changesets/cli` | Root devDependencies | `3.0.1` | `3.0.2` | [Changelog](https://github.com/changesets/changesets/blob/main/packages/cli/CHANGELOG.md#302) |

Upstream 8.1.0 adds a default message for releases without changes. The custom formatter continues to control this repository's entries. CLI 3.0.2 adds a review reminder when exiting prerelease mode and updates its internal release dependencies. See [the upstream changelog change](https://github.com/changesets/changesets/pull/2265) and [prerelease reminder](https://github.com/changesets/changesets/pull/2270).

Both versions were published on September 4 and satisfy the configured three-day minimum release age. Exact pins and the existing package manager are preserved. No post-update operations are configured. The other Changesets package declarations are current.

## Verification

- `pnpm test --run`: all 13 tests pass. The unchanged base fails the existing dependency release line test; the updated patch passes it.
- `pnpm lint`
- `pnpm tsc`
- `pnpm build`
- `pnpm --filter examples build`
- `pnpm install --frozen-lockfile`
